### PR TITLE
Development

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "types": ["@league-of-foundry-developers/foundry-vtt-types"]
+  }
+}

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,8 +4,17 @@
       "instruction": "Paste text here and click Go:"
     },
     "notifications": {
+      "nameNotFound": "Could not parse Name",
       "descriptionNotFound": "Could not parse description",
-      "fellAbilitiesNotFound": "No fell abilities were found for this creature. Please double check to make sure this is correct.",
+      "distinctiveFeaturesNotFound": "Could not parse distinctive features.",
+      "attributeLevelNotFound": "Could not parse Attribute Level.",
+      "enduranceNotFound": "Could not parse Endurance.",
+      "mightNotFound": "Could not parse Might.",
+      "hateNotFound": "Could not parse Hate/Resolve.",
+      "parryNotFound": "Could not parse Parry.",
+      "armourNotFound": "Could not parse Armour.",
+      "combatProfsNotFound": "Could not parse Combat proficiencies.",
+      "fellAbilityNotFound": "No fell abilities were found for this creature. Please double check to make sure this is correct.",
       "fellAbilitiesByType": "was automatically added without description based on creature type."
     }
   }

--- a/module.json
+++ b/module.json
@@ -2,12 +2,8 @@
   "name": "tor2e-npc-parser",
   "title": "TOR 2e NPC Parser",
   "description": "Creates an NPC adversary from a copy and pasted statblock. Tested with TOR 2e only.",
-  "authors": [
-    {
-      "name": "ThroughlyDruxy"
-    }
-  ],
-  "version": "0.0.5",
+  "authors": ["ThroughlyDruxy"],
+  "version": "0.5.0",
   "minimumCoreVersion": "9.249",
   "compatibleCoreVersion": "9.000",
   "system": ["tor2e"],
@@ -22,5 +18,5 @@
   "styles": ["styles/main.css"],
   "url": "https://github.com/ThroughlyDruxy/tor2e-npc-parser",
   "manifest": "https://raw.githubusercontent.com/ThroughlyDruxy/tor2e-npc-parser/main/module.json",
-  "download": "https://github.com/ThroughlyDruxy/tor2e-npc-parser/releases/download/v0.0.5/tor2e-npc-parser.zip"
+  "download": "https://github.com/ThroughlyDruxy/tor2e-npc-parser/releases/download/v0.5.0/tor2e-npc-parser.zip"
 }

--- a/modules/main.js
+++ b/modules/main.js
@@ -48,6 +48,7 @@ async function textInputDialog() {
   });
   dialog.render(true);
 
+  // replace "enter" key with carriage return instead of submitting ducment
   document.addEventListener('keydown', function (e) {
     if (e.key == 13) {
       if (this.classList.contains('multiline')) {

--- a/modules/parser.js
+++ b/modules/parser.js
@@ -4,6 +4,9 @@ import { buildItem } from './buildItem.js';
 export async function tor2eParser(input) {
   console.log(`TOR2E | tor2eParser() was called`);
 
+  // Statblock format
+  const statblockFormat = input.find('select#text-format').val();
+
   const npcData = {
     name: 'Generated Actor',
     type: 'adversary',
@@ -63,10 +66,7 @@ export async function tor2eParser(input) {
 
     if (nameCaps.toLowerCase() === nameFirst.toLowerCase()) {
       const betweenNamesReg = new RegExp(nameFirst + '(\\D)+ ' + nameCaps, 'g');
-      const mainDescriptionReg = /^\D*\n/;
-      let description = originalText
-        .match(mainDescriptionReg)[0]
-        .replace(/\n/gm, ' ');
+      let description = originalText.match(/^\D*\n/)[0].replace(/\n/gm, ' ');
 
       if (description.match(betweenNamesReg)) {
         npcData.data.description.value = description
@@ -74,7 +74,7 @@ export async function tor2eParser(input) {
           .replace(`${nameFirst} `, '')
           .replace(` ${nameCaps}`, '');
       } else {
-        ui.notifications.error(
+        ui.notifications.warn(
           game.i18n.localize(
             'TOR2E-NPC-PARSER.notifications.descriptionNotFound'
           )
@@ -82,7 +82,7 @@ export async function tor2eParser(input) {
       }
     }
   } else {
-    ui.notifications.error(
+    ui.notifications.warn(
       game.i18n.localize('TOR2E-NPC-PARSER.notifications.descriptionNotFound')
     );
   }
@@ -93,151 +93,238 @@ export async function tor2eParser(input) {
   );
 
   ///// ATTRIBUTE LEVEL /////
-  const attributeLevelReg = /ATTRIBUTE LEVEL\n\d+/i;
-  const attributeLevel = originalText
-    .match(attributeLevelReg)[0]
-    .match('\\d+')[0];
-
-  npcData.data.attributeLevel.value = Number(attributeLevel);
+  try {
+    const attributeLevel = originalText
+      .match(/ATTRIBUTE LEVEL\n\d+/i)[0]
+      .match(/\d+/)[0];
+    npcData.data.attributeLevel.value = Number(attributeLevel);
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize(
+        'TOR2E-NPC-PARSER.notifications.attributeLevelNotFound'
+      )
+    );
+    npcData.data.attributeLevel.value = 0;
+  }
 
   ///// ENDURANCE /////
-  // const endReg = /ENDURANCE\n\d+/i;
-  const endurance = originalText.match(/ENDURANCE\n\d+/i)[0].match('\\d+')[0];
-  npcData.data.endurance.value = endurance;
-  npcData.data.endurance.max = endurance;
+  try {
+    const endurance = originalText.match(/ENDURANCE\n\d+/i)[0].match(/\d+/)[0];
+    npcData.data.endurance.value = endurance;
+    npcData.data.endurance.max = endurance;
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.enduranceNotFound')
+    );
+    npcData.data.endurance.value = 0;
+    npcData.data.endurance.max = 0;
+  }
 
   ///// MIGHT /////
-  const mightReg = /MIGHT\n\d+/i;
-  const might = originalText.match(mightReg)[0].match('\\d+')[0];
-  npcData.data.might.value = Number(might);
-  npcData.data.might.max = Number(might);
+  try {
+    const might = originalText.match(/MIGHT\n\d+/i)[0].match(/\d+/)[0];
+    npcData.data.might.value = Number(might);
+    npcData.data.might.max = Number(might);
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.mightNotFound')
+    );
+    npcData.data.might.value = 0;
+    npcData.data.might.max = 0;
+  }
 
   ///// HATE /////
-  const hateReg = /(RESOLVE|HATE)\n\d+/i;
-  const hate = originalText.match(hateReg)[0].match('\\d+')[0];
-  npcData.data.hate.value = Number(hate);
-  npcData.data.hate.max = Number(hate);
+  try {
+    const hate = originalText.match(/(RESOLVE|HATE)\n\d+/i)[0].match(/\d+/)[0];
+    npcData.data.hate.value = Number(hate);
+    npcData.data.hate.max = Number(hate);
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.hateNotFound')
+    );
+    npcData.data.hate.value = 0;
+    npcData.data.hate.max = 0;
+  }
 
   ///// PARRY /////
-  const parryReg = /PARRY\n(\+\d|—)/i;
-  const parry = originalText.match(parryReg)[0].match('\\d+|—')[0];
-  Number(parry)
-    ? (npcData.data.parry.value = Number(parry))
-    : (npcData.data.parry.value = 0);
+  try {
+    const parry = originalText
+      .match(/PARRY\n(\+*\d|\D)/i)[0]
+      .match(/\d+|\D$/)[0];
+    Number(parry)
+      ? (npcData.data.parry.value = Number(parry))
+      : (npcData.data.parry.value = 0);
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.parryNotFound')
+    );
+    npcData.data.parry.value = 0;
+  }
 
+  // Creates actor for things to embed into
   let actor = await Actor.create(npcData);
 
   ///// ARMOUR /////
-  const armourReg = /ARMOUR\n\d/i;
-  const armour = originalText.match(armourReg)[0].match('\\d')[0];
-
-  actor.createEmbeddedDocuments('Item', [
-    buildItem('Armour', 'armour', '', 0, 0, 0, Number(armour)),
-  ]);
+  try {
+    const armour = originalText.match(/ARMOUR\n\d/i)[0].match(/\d+/)[0];
+    actor.createEmbeddedDocuments('Item', [
+      buildItem('Armour', 'armour', '', 0, 0, 0, Number(armour)),
+    ]);
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.armourNotFound')
+    );
+  }
 
   ///// DISTINCTIVE FEATURES /////
   console.log(`TOR 2E NPC PARSER | parsing Distinctive Features`);
-  const distinctiveFeatureArr = originalText.match(
-    /[A-Z][a-z]+-*[a-z]+, [A-Z][a-z]+-*[a-z]+/
-  );
-  const [featureOne, featureTwo] = distinctiveFeatureArr[0].split(', ');
-  actor.createEmbeddedDocuments('Item', [buildItem(featureOne, 'trait')]);
-  actor.createEmbeddedDocuments('Item', [buildItem(featureTwo, 'trait')]);
+  try {
+    const [featureOne, featureTwo] = originalText
+      .match(/[A-Z][a-z]+-*[a-z]+, [A-Z][a-z]+-*[a-z]+/)[0]
+      .split(', ');
+    actor.createEmbeddedDocuments('Item', [buildItem(featureOne, 'trait')]);
+    actor.createEmbeddedDocuments('Item', [buildItem(featureTwo, 'trait')]);
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize(
+        'TOR2E-NPC-PARSER.notifications.distinctiveFeaturesNotFound'
+      )
+    );
+  }
 
   ///// COMBAT PROFICIENCIES /////
   console.log(`TOR 2E NPC PARSER | parsing Combat Proficiencies`);
+  try {
+    let [weaponProfs] = originalText.match(/COMBAT PROFICIENCIES: .*\n.*/i);
+    weaponProfs = weaponProfs.split(/\),|\.\n/);
 
-  const weaponProfReg = /COMBAT PROFICIENCIES: .*(,|\.)\n.*/i;
-
-  let [weaponProfs] = originalText.match(weaponProfReg);
-  weaponProfs = weaponProfs.split(/\),|\.\n/);
-
-  for (let i = 0; i < weaponProfs.length; i++) {
-    if (/COMBAT PROFICIENCIES/i.test(weaponProfs[i])) {
-      weaponProfs[i] = weaponProfs[i].replace(/COMBAT PROFICIENCIES: /i, '');
+    for (let i = 0; i < weaponProfs.length; i++) {
+      if (/COMBAT PROFICIENCIES/i.test(weaponProfs[i])) {
+        weaponProfs[i] = weaponProfs[i].replace(/COMBAT PROFICIENCIES: /i, '');
+      } else if (/ATTRIBUTE LEVEL/i.test(weaponProfs[i])) {
+        break;
+      }
+      // Weapon name
+      let [weaponName] = weaponProfs[i].match(/\D*/);
+      const wepSkillDamageInjuryReg = /\d+/g;
+      let [weaponSkill, weaponDamage, weaponInjury] = weaponProfs[i].match(
+        wepSkillDamageInjuryReg
+      );
+      actor.createEmbeddedDocuments('Item', [
+        buildItem(
+          weaponName,
+          'weapon',
+          '',
+          Number(weaponSkill),
+          Number(weaponDamage),
+          Number(weaponInjury)
+        ),
+      ]);
     }
-    // Weapon name
-    let [weaponName] = weaponProfs[i].match(/\D*/);
-    const wepSkillDamageInjuryReg = /\d+/g;
-    // Weapon skill, damage, and injury
-    let [weaponSkill, weaponDamage, weaponInjury] = weaponProfs[i].match(
-      wepSkillDamageInjuryReg
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.combatProfsNotFound')
     );
-
-    actor.createEmbeddedDocuments('Item', [
-      buildItem(
-        weaponName,
-        'weapon',
-        '',
-        Number(weaponSkill),
-        Number(weaponDamage),
-        Number(weaponInjury)
-      ),
-    ]);
   }
 
   ///// FELL ABILITIES /////
   console.log(`TOR 2E NPC PARSER | parsing Fell Abilities`);
-  let allFellAbilitiesArr = originalText
-    .match(/FELL ABILITIES: (\D*\d*)+/gim)[0]
-    .replace(/FELL ABILITIES: /i, '')
-    .split(/\.\n/gm);
+  try {
+    let allFellAbilitiesArr = originalText
+      .match(/FELL ABILITIES: (\D*\d*)+/gim)[0]
+      .replace(/FELL ABILITIES: /i, '')
+      .split(/\.\n/gm);
 
-  for (let i = 0; i < allFellAbilitiesArr.length; i++) {
-    const [fellAbilitiesName, fellAbilitiesDescription] = allFellAbilitiesArr[i]
-      .replace('\n', ' ')
-      .split('.');
+    for (let i = 0; i < allFellAbilitiesArr.length; i++) {
+      const [fellAbilitiesName, fellAbilitiesDescription] = allFellAbilitiesArr[
+        i
+      ]
+        .replace('\n', ' ')
+        .split('.');
 
-    if (typeof fellAbilitiesDescription !== 'undefined') {
-      actor.createEmbeddedDocuments('Item', [
-        buildItem(
-          fellAbilitiesName,
-          'fell-ability',
-          fellAbilitiesDescription + '.'
-        ),
-      ]);
-    } else {
-      ui.notifications.error(
-        game.i18n.localize(
-          'TOR2E-NPC-PARSER.notifications.fellAbilitiesNotFound'
-        )
-      );
+      if (typeof fellAbilitiesDescription !== 'undefined') {
+        actor.createEmbeddedDocuments('Item', [
+          buildItem(
+            fellAbilitiesName,
+            'fell-ability',
+            fellAbilitiesDescription + '.'
+          ),
+        ]);
+      }
     }
+  } catch (error) {
+    console.error(error);
+    ui.notifications.warn(
+      game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilityNotFound')
+    );
   }
 
   ///// FELL ABILITIES BY TYPE /////
-  if (npcData.name.match('Orc|Goblin')) {
-    actor.createEmbeddedDocuments('Item', [
-      buildItem(
-        'Hate Sunlight',
-        'fell-ability',
-        'Description can be found on page 148'
-      ),
-    ]);
-    ui.notifications.info(
-      'Hate Sunlight ' +
-        game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
-    );
-  } else if (npcData.name.match('troll|Troll')) {
+  if (/Orc|Goblin|Uruk|Snaga|Lugburz|Hags|Pale Ones/i.test(npcData.name)) {
+    if (statblockFormat === 'crb') {
+      actor.createEmbeddedDocuments('Item', [
+        buildItem(
+          'Hatred (subject)',
+          'fell-ability',
+          'Not all orcs have this ability, but the LM may add it if they desire. Simply remove if not desired. Description can be found on page 148 of the Core Rule Book.'
+        ),
+      ]);
+      actor.createEmbeddedDocuments('Item', [
+        buildItem(
+          'Hate Sunlight',
+          'fell-ability',
+          'Description can be found on page 148 of the Core Rule Book.'
+        ),
+      ]);
+      ui.notifications.info(
+        'Hatred (subject) and Hate Sunlight ' +
+          game.i18n.localize(
+            'TOR2E-NPC-PARSER.notifications.fellAbilitiesByType'
+          )
+      );
+    } else if (statblockFormat === 'adversary-conversion') {
+      actor.createEmbeddedDocuments('Item', [
+        buildItem(
+          'Hatred (subject)',
+          'fell-ability',
+          'Description can be found on page 4  of the Adversary Conversion pdf.'
+        ),
+      ]);
+      ui.notifications.info(
+        'Hatred (subject) ' +
+          game.i18n.localize(
+            'TOR2E-NPC-PARSER.notifications.fellAbilitiesByType'
+          )
+      );
+    }
+  } else if (/Troll|Ettins|Ogre/i.test(npcData.name)) {
     actor.createEmbeddedDocuments('Item', [
       buildItem(
         'Hideous Toughness',
         'fell-ability',
-        'Description can be found on page 151'
+        'Description can be found on page 151 of the Core Rule Book or page 8 of the Adversary Conversion pdf.'
       ),
     ]);
     actor.createEmbeddedDocuments('Item', [
       buildItem(
         'Dull-witted',
         'fell-ability',
-        'Description can be found on page 151'
+        'Description can be found on page 151 of the Core Rule Book or page 8 of the Adversary Conversion pdf.'
       ),
     ]);
     ui.notifications.info(
       'Hideous Toughness and Dull-witted ' +
         game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
     );
-  } else if (npcData.name.match('wight|Marsh|Wraith')) {
+  } else if (/Wight|Marsh|Wraith|Bog Soldiers|Spectres/i.test(npcData.name)) {
     actor.createEmbeddedDocuments('Item', [
       buildItem(
         'Deathless',
@@ -263,7 +350,7 @@ export async function tor2eParser(input) {
       'Deathless, Heartless, and Strike Fear ' +
         game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
     );
-  } else if (npcData.name.match('Wolf|Hound')) {
+  } else if (/Wolf|Hound/i.test(npcData.name)) {
     actor.createEmbeddedDocuments('Item', [
       buildItem(
         'Great Leap',
@@ -273,6 +360,77 @@ export async function tor2eParser(input) {
     ]);
     ui.notifications.info(
       'Great Leap ' +
+        game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
+    );
+  } else if (/Attercop|Spider/i.test(npcData.name)) {
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Poison',
+        'fell-ability',
+        'If a Sting attack results in a Wound, the target is also poisoned.'
+      ),
+    ]);
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Web',
+        'fell-ability',
+        'If and attack with the Web quality successfully hits a target, that target is webbed and unable to move. The webbed target cannot change stance and suffers –4 to their Parry rating. The webbed target may free themselves by succeeding on an ATHLETICS roll.'
+      ),
+    ]);
+    ui.notifications.info(
+      'Poison and Web ' +
+        game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
+    );
+  } else if (/Bat|Shadow/i.test(npcData.name)) {
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Hate Sunlight',
+        'fell-ability',
+        'The creature loses 1 Hate at the start of each round it is exposed to the full light of the sun.'
+      ),
+    ]);
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Denizen of the Dark',
+        'fell-ability',
+        'All attack rolls are Favoured while in darkness.'
+      ),
+    ]);
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Fell Speed',
+        'fell-ability',
+        'At the beginning of each turn, this creature can choose which hero it engages regardless of restrictions, or it can abandon combat entirely.'
+      ),
+    ]);
+    ui.notifications.info(
+      'Hate Sunlight, Deizen of the Dark, and Fell Speed ' +
+        game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
+    );
+  } else if (/Huorns/i.test(npcData.name)) {
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Wandering Huorn',
+        'fell-ability',
+        'A wandering Huorn is most often a young tree whose heart darkened rapidly, and who is still quick of limb and root. (The Huorn template below is a Wandering Huorn).'
+      ),
+    ]);
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Denizen of the Dark',
+        'fell-ability',
+        'A dark-hearted Huorn may be a young tree awakened by a deep hatred, or an ancient monster brooding since uncounted centuries. (Increase Endurance by 15, Add +2 Hate Score, Add +1 Armor, Add +1 to Bough Lash Rating, Add Fell Ability Horrible Strength).'
+      ),
+    ]);
+    actor.createEmbeddedDocuments('Item', [
+      buildItem(
+        'Fell Speed',
+        'fell-ability',
+        'A dark-hearted Huorn may be a young tree awakened by a deep hatred, or an ancient monster brooding since uncounted centuries. (Increase Endurance by 25, Add +3 Hate Score, Add +1 to Bough Lash Rating, Remove Fell Ability Hatred, Add Fell Abilities Horrible Strength, Strike Fear, and Thick Hide).'
+      ),
+    ]);
+    ui.notifications.info(
+      'Wandering Huorn, Denizen of the Dark, and Fell Speed ' +
         game.i18n.localize('TOR2E-NPC-PARSER.notifications.fellAbilitiesByType')
     );
   }

--- a/modules/parser.js
+++ b/modules/parser.js
@@ -92,28 +92,46 @@ export async function tor2eParser(input) {
     `TOR 2E NPC PARSER | parsing Level, Endurance, Might, Hate, Parry, and Armour`
   );
 
-  const attEndMigHateParArmArray = originalText.match(/^–*—*\+*\d*$/gm);
+  ///// ATTRIBUTE LEVEL /////
+  const attributeLevel = originalText
+    .match('ATTRIBUTE LEVEL\n\\d+')[0]
+    .match('\\d+')[0];
 
-  // Add level, endurance, might, resolve, and parry to npcData
-  const [attributeLevel, endurance, might, hate, parry, armour] =
-    attEndMigHateParArmArray;
   npcData.data.attributeLevel.value = Number(attributeLevel);
-  npcData.data.endurance.value = Number(endurance);
-  npcData.data.endurance.max = Number(endurance);
+
+  console.log(`TOR 2E NPC PARSER | attributeLevel: ${attributeLevel}`);
+
+  ///// ENDURANCE /////
+  const endReg = /ENDURANCE\n\d+/i;
+  const endurance = originalText.match(endReg)[0].match('\\d+')[0];
+  npcData.data.endurance.value = endurance;
+  npcData.data.endurance.max = endurance;
+
+  ///// MIGHT /////
+  const mightReg = /MIGHT\n\d+/i;
+  const might = originalText.match(mightReg)[0].match('\\d+')[0];
   npcData.data.might.value = Number(might);
   npcData.data.might.max = Number(might);
+
+  ///// HATE /////
+  const hateReg = /(RESOLVE|HATE)\n\d+/i;
+  const hate = originalText.match(hateReg)[0].match('\\d+')[0];
   npcData.data.hate.value = Number(hate);
   npcData.data.hate.max = Number(hate);
 
-  if (/\d/.test(parry)) {
-    npcData.data.parry.value = Number(attEndMigHateParArmArray[4]);
-  } else {
-    npcData.data.parry.value = 0;
-  }
+  ///// PARRY /////
+  const parryReg = /PARRY\n(\+\d|—)/i;
+  const parry = originalText.match(parryReg)[0].match('\\d+|—')[0];
+  Number(parry)
+    ? (npcData.data.parry.value = Number(parry))
+    : (npcData.data.parry.value = 0);
 
   let actor = await Actor.create(npcData);
 
   ///// ARMOUR /////
+  const armourReg = /ARMOUR\n\d/i;
+  const armour = originalText.match(armourReg)[0].match('\\d')[0];
+
   actor.createEmbeddedDocuments('Item', [
     buildItem('Armour', 'armour', '', 0, 0, 0, Number(armour)),
   ]);

--- a/modules/parser.js
+++ b/modules/parser.js
@@ -93,17 +93,16 @@ export async function tor2eParser(input) {
   );
 
   ///// ATTRIBUTE LEVEL /////
+  const attributeLevelReg = /ATTRIBUTE LEVEL\n\d+/i;
   const attributeLevel = originalText
-    .match('ATTRIBUTE LEVEL\n\\d+')[0]
+    .match(attributeLevelReg)[0]
     .match('\\d+')[0];
 
   npcData.data.attributeLevel.value = Number(attributeLevel);
 
-  console.log(`TOR 2E NPC PARSER | attributeLevel: ${attributeLevel}`);
-
   ///// ENDURANCE /////
-  const endReg = /ENDURANCE\n\d+/i;
-  const endurance = originalText.match(endReg)[0].match('\\d+')[0];
+  // const endReg = /ENDURANCE\n\d+/i;
+  const endurance = originalText.match(/ENDURANCE\n\d+/i)[0].match('\\d+')[0];
   npcData.data.endurance.value = endurance;
   npcData.data.endurance.max = endurance;
 
@@ -148,17 +147,17 @@ export async function tor2eParser(input) {
   ///// COMBAT PROFICIENCIES /////
   console.log(`TOR 2E NPC PARSER | parsing Combat Proficiencies`);
 
-  const weaponProfReg = /COMBAT PROFICIENCIES: .*\n.*/;
+  const weaponProfReg = /COMBAT PROFICIENCIES: .*(,|\.)\n.*/i;
 
   let [weaponProfs] = originalText.match(weaponProfReg);
-  weaponProfs = weaponProfs.split('),');
+  weaponProfs = weaponProfs.split(/\),|\.\n/);
 
   for (let i = 0; i < weaponProfs.length; i++) {
-    if (/COMBAT PROFICIENCIES/.test(weaponProfs[i])) {
-      weaponProfs[i] = weaponProfs[i].replace('COMBAT PROFICIENCIES: ', '');
+    if (/COMBAT PROFICIENCIES/i.test(weaponProfs[i])) {
+      weaponProfs[i] = weaponProfs[i].replace(/COMBAT PROFICIENCIES: /i, '');
     }
     // Weapon name
-    let [weaponName] = weaponProfs[i].match('\\D*');
+    let [weaponName] = weaponProfs[i].match(/\D*/);
     const wepSkillDamageInjuryReg = /\d+/g;
     // Weapon skill, damage, and injury
     let [weaponSkill, weaponDamage, weaponInjury] = weaponProfs[i].match(
@@ -180,8 +179,8 @@ export async function tor2eParser(input) {
   ///// FELL ABILITIES /////
   console.log(`TOR 2E NPC PARSER | parsing Fell Abilities`);
   let allFellAbilitiesArr = originalText
-    .match(/FELL ABILITIES: (\D*\d*)+/gm)[0]
-    .replace('FELL ABILITIES: ', '')
+    .match(/FELL ABILITIES: (\D*\d*)+/gim)[0]
+    .replace(/FELL ABILITIES: /i, '')
     .split(/\.\n/gm);
 
   for (let i = 0; i < allFellAbilitiesArr.length; i++) {

--- a/templates/tor2e-npc-parser.hbs
+++ b/templates/tor2e-npc-parser.hbs
@@ -1,4 +1,9 @@
 <form id='text-input-form' class='form-rest'>
+  <p>Document statblock was copied from:</p>
+  <select name='inputFormat' id='text-format'>
+    <option value='crb'>Core Rules</option>
+    <option value='adversary-conversion'>Adversary Conversion.pdf</option>
+  </select>
   <p>{{localize 'TOR2E-NPC-PARSER.dialog.instruction'}}</p>
   <label class='text'>
     <textarea id='text-input' rows='10' cols='100'></textarea>


### PR DESCRIPTION
Removed styles/main.css as it was unused

changed templates/tor2e-npc-parser.hbs to have the option for Adversary Conversion.pdf

Refactored how various parts are collected from the text so it works with Adversary Conversion.pdf

Added error and notifications when it goes wrong (many try...catch blocks)

Error used to be thrown when only one weapon proficiency was on the statblock, now it does not.